### PR TITLE
Fix partial scss and sass files minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-prettier": "^4.0.0",
-    "npm-check-updates": "^11.8.5",
+    "npm-check-updates": "^16.10.8",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
     "prettier-config-udes": "1.0.2"

--- a/src/files-minifier.js
+++ b/src/files-minifier.js
@@ -12,6 +12,9 @@ module.exports = (value, outputPath) => {
 
   // CSS
   if (pathEndBy(".css")) {
+    if (!value) {
+      return;
+    }
     return prettyData.cssmin(value);
   }
 


### PR DESCRIPTION
Partial scss and sass files are imported in the main sass files are not writen separately as css files. 
However they are still exist in the stack. 
Make sure theese partial style files won't break the flow. 